### PR TITLE
fix: repair broken JSX header structure in App.tsx

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -46,6 +46,11 @@ Workshop flow for team name, symbol, values, and working agreements (Identity Sy
 
 ## Agent Log
 
+### 2026-05-22 — fix: repair broken JSX header structure in App.tsx (CI blocker)
+- Done: fixed duplicate `<a>` logo link and unclosed `<div>` tags in `showLearn` header; fixed premature `</div></div>` closing tags in main header (lines 133–152); build now passes
+- Status restored to stable; blockers cleared
+- Next task: check issues for human feedback; implement #10 (write `team-identity:lastSession` in `App.tsx` `saveCharter()`) if approved; implement #11 (print @media CSS) if approved; implement #12 (keyboard a11y) if approved
+
 ### 2026-05-17 — research: draft auto-save, Change Planner integration, facilitator mode
 - Done: checked open issues — all open issues have needs-review label; #3 implemented, #8 scoped to scrum-facilitator; no actionable approved/incomplete/changes-requested/research-more items
 - Created issue #17 (draft auto-save: write team-identity:draft on step transitions; resume banner on mount; prevent data loss in in-person workshops)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -76,31 +76,19 @@ export default function App() {
           <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
             <div className="flex items-center gap-2">
               <a
-                            href="https://agile-toolkit.github.io/"
-                            title="Agile Toolkit"
-                            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
-                          >
-                            <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-                              <rect x="1" y="1" width="6" height="6" rx="1"/>
-                              <rect x="9" y="1" width="6" height="6" rx="1"/>
-                              <rect x="1" y="9" width="6" height="6" rx="1"/>
-                              <rect x="9" y="9" width="6" height="6" rx="1"/>
-                            </svg>
-                          </a>
-            <div className="flex items-center gap-2">
-              <a
-                            href="https://agile-toolkit.github.io/"
-                            title="Agile Toolkit"
-                            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
-                          >
-                            <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-                              <rect x="1" y="1" width="6" height="6" rx="1"/>
-                              <rect x="9" y="1" width="6" height="6" rx="1"/>
-                              <rect x="1" y="9" width="6" height="6" rx="1"/>
-                              <rect x="9" y="9" width="6" height="6" rx="1"/>
-                            </svg>
-                          </a>
-            <button onClick={() => setShowLearn(false)} className="font-semibold text-brand-600">{t('app.title')}</button>
+                href="https://agile-toolkit.github.io/"
+                title="Agile Toolkit"
+                className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
+              >
+                <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
+                  <rect x="1" y="1" width="6" height="6" rx="1"/>
+                  <rect x="9" y="1" width="6" height="6" rx="1"/>
+                  <rect x="1" y="9" width="6" height="6" rx="1"/>
+                  <rect x="9" y="9" width="6" height="6" rx="1"/>
+                </svg>
+              </a>
+              <button onClick={() => setShowLearn(false)} className="font-semibold text-brand-600">{t('app.title')}</button>
+            </div>
             <select
               value={i18n.language.split('-')[0]}
               onChange={e => i18n.changeLanguage(e.target.value)}
@@ -133,8 +121,6 @@ export default function App() {
       <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
         <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
           <button onClick={() => setStep('intro')} className="font-semibold text-brand-600">{t('app.title')}</button>
-            </div>
-            </div>
           <div className="flex items-center gap-1">
             <button onClick={() => setShowLearn(true)} className="btn-ghost">{t('learn.title')}</button>
             <select


### PR DESCRIPTION
## Summary
Fixed critical JSX syntax errors in the header components that were blocking the build. Removed duplicate logo link and corrected mismatched/unclosed `<div>` tags in both the `showLearn` modal header and main app header.

## Changes
- **Removed duplicate logo link** — The `showLearn` header had two identical `<a>` elements linking to the Agile Toolkit homepage; kept one and removed the duplicate
- **Fixed unclosed `<div>` wrapper** — The first `<a>` logo link was missing its parent `<div className="flex items-center gap-2">` closing tag; properly closed it before the button
- **Removed premature closing tags** — Deleted two stray `</div></div>` tags at lines 136–137 in the main header that were closing divs prematurely and breaking layout structure
- **Corrected indentation** — Normalized whitespace and indentation for consistency with project style

## Result
Build now passes. Header layout is structurally sound and renders correctly. No functional changes to behavior or styling—purely structural JSX repair.

https://claude.ai/code/session_01FE5R2VG2BHaBCVUPBjSmhE