### PR TITLE
feat: unify header with shared AppHeader component (#20)

### DIFF
--- a/.artefacts/BRIEF.md
+++ b/.artefacts/BRIEF.md
@@ -22,6 +22,7 @@ Workshop flow for team name, symbol, values, and working agreements (Identity Sy
 - [x] Multi-team support (#26) — `team-identity:charters` localStorage key stores `Array<SavedCharter>` (max 20); "Save to My Teams" inline form on charter step with custom library name; "My Teams" screen lists saved charters with Load/Rename/Delete actions; loading a charter restores full charter state and navigates to charter step; "My Teams (N)" button on intro screen when library non-empty; `teams.*` i18n keys in EN/ES/BE/RU; `SavedCharter` type in `types.ts`
 - [x] Scrum values alignment (#15) — static `src/data/scrum-values-map.ts` maps each value card to 0–2 Scrum values (Commitment/Courage/Focus/Openness/Respect); "Scrum Alignment" toggle button on charter step; when enabled, each selected value badge shows its Scrum tag(s) below it; coverage row at bottom of charter card shows 5 Scrum values with ✓/strikethrough per coverage; i18n keys `charter.scrum_toggle_show/hide/coverage` in EN/ES/BE/RU; no new dependencies
 - [x] Print-optimized charter layout (#11) — `@media print` block in `src/index.css` hides `header` and `.no-print` elements (progress bar, charter action buttons, save-to-library section, history panel, back button); `#charter-card` gets white background, no gradient, no shadow, 0.5rem radius, and gray border for printing; `#charter-card *` text overrides to `#1f2937`; `document.title` dynamically set to `"[TeamName] — Team Charter"` on charter step via `useEffect`; no new dependencies
+- [x] Unified header component (#20) — `src/components/AppHeader.tsx` + `LanguagePicker.tsx` copied from `design-system/components/`; replaces all 3 inline `<header>` blocks (main workshop, showLearn, showMyTeams) with `<AppHeader>`; local `hideLanguagePicker` prop added (app-specific extension, not in design-system source) so facilitator mode still hides the language switcher; children slot carries the Learn button and facilitator toggle
 
 ## localStorage keys
 
@@ -52,7 +53,7 @@ Workshop flow for team name, symbol, values, and working agreements (Identity Sy
 - [ ] [#18] Integration: Change Planner — read team-identity-charter to pre-fill team context in change scenarios (scoped to change-planner repo)
 - [x] [#19] UX: Facilitator/projector display mode — CSS class toggle for larger text and cards on projected displays
 - [x] [#26] Feature: Multi-team support — charter library in `team-identity:charters`, My Teams screen with Load/Rename/Delete actions per charter
-- [ ] [#20] UX: Unify header — copy `AppHeader.tsx` + `LanguagePicker.tsx` from design-system into `src/components/`, replace both header blocks (main app + showLearn) with unified component — auto-approved 2026-06-29
+- [x] [#20] UX: Unify header — copy `AppHeader.tsx` + `LanguagePicker.tsx` from design-system into `src/components/`, replace all 3 header blocks (main app, showLearn, showMyTeams) with unified component — implemented
 - [ ] [#21] Feature: Light/dark theme — `darkMode: 'class'` in tailwind.config.js, anti-flash inline script in index.html, `ThemeToggle.tsx` from design-system, `dark:` Tailwind variants on all color classes — auto-approved 2026-06-29
 
 ## Tech notes
@@ -61,6 +62,11 @@ Workshop flow for team name, symbol, values, and working agreements (Identity Sy
 - GitHub Project #13 created for this repo (project ID: `PVT_kwDOEGuPAc4BXTDB`).
 
 ## Agent Log
+
+### 2026-07-02 — feat: Unified header component (#20)
+- Done: copied `AppHeader.tsx` + `LanguagePicker.tsx` from `design-system/components/` into `src/components/`; added a local `hideLanguagePicker` prop to `AppHeader.tsx` (not in the shared source) so the existing facilitator-mode behavior of hiding the language switcher still works; replaced all 3 inline `<header>` blocks (main workshop screen, showLearn screen, showMyTeams screen — one more than the issue described, since #26 added a third header since the issue was filed) with `<AppHeader>`; removed the now-unused `i18n` destructure from `useTranslation()`; verified visually via a local preview build + headless-browser screenshots across all 3 screens; `npm run build` passes
+- Remaining: none — #20 fully implemented
+- Next task: check issues for human feedback; implement #21 (light/dark theme — `darkMode: 'class'` in tailwind.config.js, anti-flash inline script in index.html, `ThemeToggle.tsx` from design-system, `dark:` Tailwind variants across `src/`) if still approved
 
 ### 2026-06-29 — feat: Print-optimized charter layout (#11)
 - Done: `@media print` block in `src/index.css` — hides `header` and `.no-print` elements (progress bar, charter action buttons, save-to-library section, history panel, back button); `#charter-card` prints white background with gray border, no gradient/shadow/large radius; `#charter-card *` text overrides to `#1f2937` for readability; `document.title` set to `"[TeamName] — Team Charter"` on charter step via `useEffect` (resets on navigation); `no-print` class added to 5 DOM elements in `App.tsx`; no new dependencies; auto-approved #11 (50 days), #20 (40 days), #21 (40 days)

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -4,6 +4,7 @@ import html2canvas from 'html2canvas'
 import type { WorkshopStep, WorkingAgreement, TeamCharter, SavedCharter, HistoryEntry } from './types'
 import { SYMBOLS, VALUE_CARDS, AGREEMENT_PROMPTS } from './data/symbols'
 import { SCRUM_VALUES, SCRUM_VALUE_MAP } from './data/scrum-values-map'
+import AppHeader from './components/AppHeader'
 
 const STORAGE_KEY = 'team-identity-charter'
 const DRAFT_KEY = 'team-identity:draft'
@@ -94,7 +95,7 @@ function ProjectorIcon({ className }: { className?: string }) {
 }
 
 export default function App() {
-  const { t, i18n } = useTranslation()
+  const { t } = useTranslation()
   const [step, setStep] = useState<WorkshopStep>('intro')
   const [charter, setCharter] = useState<TeamCharter>(defaultCharter)
   const [customValue, setCustomValue] = useState('')
@@ -369,25 +370,7 @@ export default function App() {
   if (showMyTeams) {
     return (
       <div className="min-h-screen flex flex-col">
-        <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-          <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <a
-                href="https://agile-toolkit.github.io/"
-                title="Agile Toolkit"
-                className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
-              >
-                <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-                  <rect x="1" y="1" width="6" height="6" rx="1"/>
-                  <rect x="9" y="1" width="6" height="6" rx="1"/>
-                  <rect x="1" y="9" width="6" height="6" rx="1"/>
-                  <rect x="9" y="9" width="6" height="6" rx="1"/>
-                </svg>
-              </a>
-              <button onClick={() => setShowMyTeams(false)} className="font-semibold text-brand-600">{t('app.title')}</button>
-            </div>
-          </div>
-        </header>
+        <AppHeader title={t('app.title')} onTitleClick={() => setShowMyTeams(false)} />
         <main className="flex-1 max-w-2xl mx-auto w-full px-4 py-8">
           <div className="flex items-center justify-between mb-6">
             <h1 className="text-2xl font-bold">{t('teams.title')}</h1>
@@ -448,40 +431,9 @@ export default function App() {
   if (showLearn) {
     return (
       <div className="min-h-screen flex flex-col">
-        <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-          <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
-            <div className="flex items-center gap-2">
-              <a
-                href="https://agile-toolkit.github.io/"
-                title="Agile Toolkit"
-                className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
-              >
-                <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor">
-                  <rect x="1" y="1" width="6" height="6" rx="1"/>
-                  <rect x="9" y="1" width="6" height="6" rx="1"/>
-                  <rect x="1" y="9" width="6" height="6" rx="1"/>
-                  <rect x="9" y="9" width="6" height="6" rx="1"/>
-                </svg>
-              </a>
-              <button onClick={() => setShowLearn(false)} className="font-semibold text-brand-600">{t('app.title')}</button>
-            </div>
-            <div className="flex items-center gap-1">
-              {facilitatorBtn}
-              {!facilitatorMode && (
-                <select
-                  value={i18n.language.split('-')[0]}
-                  onChange={e => i18n.changeLanguage(e.target.value)}
-                  className="text-sm text-gray-500 px-2 py-1 rounded hover:bg-gray-100 bg-transparent border-none cursor-pointer"
-                >
-                  <option value="en">EN</option>
-                  <option value="es">ES</option>
-                  <option value="be">BE</option>
-                  <option value="ru">RU</option>
-                </select>
-              )}
-            </div>
-          </div>
-        </header>
+        <AppHeader title={t('app.title')} onTitleClick={() => setShowLearn(false)} hideLanguagePicker={facilitatorMode}>
+          {facilitatorBtn}
+        </AppHeader>
         <main className="flex-1 max-w-2xl mx-auto w-full px-4 py-8 space-y-6">
           <h1 className="text-2xl font-bold">{t('learn.title')}</h1>
           <div className="card">
@@ -499,29 +451,12 @@ export default function App() {
 
   return (
     <div className="min-h-screen flex flex-col">
-      <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
-        <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between">
-          <button onClick={() => setStep('intro')} className="font-semibold text-brand-600">{t('app.title')}</button>
-          <div className="flex items-center gap-1">
-            {!facilitatorMode && (
-              <button onClick={() => setShowLearn(true)} className="btn-ghost">{t('learn.title')}</button>
-            )}
-            {facilitatorBtn}
-            {!facilitatorMode && (
-              <select
-                value={i18n.language.split('-')[0]}
-                onChange={e => i18n.changeLanguage(e.target.value)}
-                className="ml-1 text-sm text-gray-500 px-2 py-1 rounded hover:bg-gray-100 bg-transparent border-none cursor-pointer"
-              >
-                <option value="en">EN</option>
-                <option value="es">ES</option>
-                <option value="be">BE</option>
-                <option value="ru">RU</option>
-              </select>
-            )}
-          </div>
-        </div>
-      </header>
+      <AppHeader title={t('app.title')} onTitleClick={() => setStep('intro')} hideLanguagePicker={facilitatorMode}>
+        {!facilitatorMode && (
+          <button onClick={() => setShowLearn(true)} className="btn-ghost">{t('learn.title')}</button>
+        )}
+        {facilitatorBtn}
+      </AppHeader>
 
       {/* Progress bar — hidden in facilitator mode */}
       {step !== 'intro' && !facilitatorMode && (

--- a/src/components/AppHeader.tsx
+++ b/src/components/AppHeader.tsx
@@ -1,0 +1,93 @@
+import LanguagePicker from './LanguagePicker'
+
+/**
+ * Copied from design-system/components/AppHeader.tsx.
+ * Requires: react-i18next.
+ *
+ * hideLanguagePicker: local addition — Team Identity's facilitator mode hides
+ * the language switcher to reduce UI noise on a projected screen.
+ */
+
+interface NavItem {
+  key: string
+  label: string
+  active: boolean
+  onClick: () => void
+}
+
+interface AppHeaderProps {
+  title: string
+  onTitleClick?: () => void
+  navItems?: NavItem[]
+  hideLanguagePicker?: boolean
+  children?: React.ReactNode
+}
+
+const DASHBOARD_URL = 'https://agile-toolkit.github.io/'
+
+const GridIcon = () => (
+  <svg className="w-4 h-4" viewBox="0 0 16 16" fill="currentColor" aria-hidden="true">
+    <rect x="1" y="1" width="6" height="6" rx="1"/>
+    <rect x="9" y="1" width="6" height="6" rx="1"/>
+    <rect x="1" y="9" width="6" height="6" rx="1"/>
+    <rect x="9" y="9" width="6" height="6" rx="1"/>
+  </svg>
+)
+
+export default function AppHeader({ title, onTitleClick, navItems, hideLanguagePicker, children }: AppHeaderProps) {
+  return (
+    <header className="bg-white border-b border-gray-200 sticky top-0 z-10">
+      <div className="max-w-3xl mx-auto px-4 h-14 flex items-center justify-between gap-4">
+
+        {/* Left: dashboard link + app title */}
+        <div className="flex items-center gap-2 flex-shrink-0">
+          <a
+            href={DASHBOARD_URL}
+            title="Agile Toolkit — back to dashboard"
+            className="text-gray-400 hover:text-gray-600 transition-colors flex-shrink-0"
+          >
+            <GridIcon />
+          </a>
+          {onTitleClick ? (
+            <button
+              type="button"
+              onClick={onTitleClick}
+              className="font-semibold text-brand-600 hover:text-brand-700 transition-colors"
+            >
+              {title}
+            </button>
+          ) : (
+            <span className="font-semibold text-brand-600">{title}</span>
+          )}
+        </div>
+
+        {/* Right: optional nav pills + language picker + children slot */}
+        <div className="flex items-center gap-1 min-w-0">
+          {navItems && navItems.length > 0 && (
+            <nav className="flex items-center gap-0.5 mr-1">
+              {navItems.map(item => (
+                <button
+                  key={item.key}
+                  type="button"
+                  onClick={item.onClick}
+                  className={`px-3 py-1.5 rounded-lg text-sm font-medium transition-colors whitespace-nowrap ${
+                    item.active
+                      ? 'bg-brand-50 text-brand-700'
+                      : 'text-gray-500 hover:bg-gray-100 hover:text-gray-700'
+                  }`}
+                >
+                  {item.label}
+                </button>
+              ))}
+            </nav>
+          )}
+
+          {!hideLanguagePicker && <LanguagePicker />}
+
+          {children}
+        </div>
+
+      </div>
+    </header>
+  )
+}

--- a/src/components/LanguagePicker.tsx
+++ b/src/components/LanguagePicker.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useRef, useState } from 'react'
+import { useTranslation } from 'react-i18next'
+
+/**
+ * Copied from design-system/components/LanguagePicker.tsx.
+ * Requires: react-i18next, configured with en / es / be / ru locales.
+ */
+
+const LANGUAGES = [
+  { code: 'en', label: 'EN' },
+  { code: 'es', label: 'ES' },
+  { code: 'be', label: 'BE' },
+  { code: 'ru', label: 'RU' },
+] as const
+
+type LangCode = (typeof LANGUAGES)[number]['code']
+
+function currentCode(language: string): LangCode {
+  const code = language.slice(0, 2) as LangCode
+  return LANGUAGES.some(l => l.code === code) ? code : 'en'
+}
+
+export default function LanguagePicker() {
+  const { i18n } = useTranslation()
+  const [open, setOpen] = useState(false)
+  const ref = useRef<HTMLDivElement>(null)
+  const active = LANGUAGES.find(l => l.code === currentCode(i18n.language))!
+
+  useEffect(() => {
+    if (!open) return
+    const handler = (e: MouseEvent) => {
+      if (ref.current && !ref.current.contains(e.target as Node)) setOpen(false)
+    }
+    document.addEventListener('mousedown', handler)
+    return () => document.removeEventListener('mousedown', handler)
+  }, [open])
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Escape') { setOpen(false); return }
+    if (!open && (e.key === 'Enter' || e.key === ' ' || e.key === 'ArrowDown')) {
+      e.preventDefault(); setOpen(true); return
+    }
+    if (open && (e.key === 'ArrowDown' || e.key === 'ArrowUp')) {
+      e.preventDefault()
+      const idx = LANGUAGES.findIndex(l => l.code === currentCode(i18n.language))
+      const next = e.key === 'ArrowDown'
+        ? (idx + 1) % LANGUAGES.length
+        : (idx - 1 + LANGUAGES.length) % LANGUAGES.length
+      i18n.changeLanguage(LANGUAGES[next].code)
+    }
+  }
+
+  return (
+    <div ref={ref} className="relative" onKeyDown={handleKeyDown}>
+      <button
+        type="button"
+        onClick={() => setOpen(v => !v)}
+        aria-haspopup="listbox"
+        aria-expanded={open}
+        className="flex items-center gap-1 px-2.5 py-1.5 rounded-lg text-sm font-medium text-gray-600 hover:bg-gray-100 transition-colors select-none"
+      >
+        <span>{active.label}</span>
+        <svg className={`w-3 h-3 text-gray-400 transition-transform ${open ? 'rotate-180' : ''}`} viewBox="0 0 12 12" fill="none" stroke="currentColor" strokeWidth="1.5">
+          <path d="M2 4l4 4 4-4" strokeLinecap="round" strokeLinejoin="round"/>
+        </svg>
+      </button>
+
+      {open && (
+        <ul
+          role="listbox"
+          aria-label="Language"
+          className="absolute right-0 top-full mt-1 bg-white border border-gray-200 rounded-xl shadow-lg py-1 z-50 min-w-[110px]"
+        >
+          {LANGUAGES.map(lang => {
+            const isCurrent = lang.code === currentCode(i18n.language)
+            return (
+              <li
+                key={lang.code}
+                role="option"
+                aria-selected={isCurrent}
+              >
+                <button
+                  type="button"
+                  onClick={() => { i18n.changeLanguage(lang.code); setOpen(false) }}
+                  className={`w-full flex items-center gap-2 px-3 py-1.5 text-sm transition-colors ${
+                    isCurrent
+                      ? 'bg-brand-50 text-brand-700 font-semibold'
+                      : 'text-gray-700 hover:bg-gray-50'
+                  }`}
+                >
+                  <span>{lang.label}</span>
+                  {isCurrent && (
+                    <svg className="ml-auto w-3.5 h-3.5 text-brand-600" viewBox="0 0 14 14" fill="none" stroke="currentColor" strokeWidth="2">
+                      <path d="M2 7l3.5 3.5L12 3" strokeLinecap="round" strokeLinejoin="round"/>
+                    </svg>
+                  )}
+                </button>
+              </li>
+            )
+          })}
+        </ul>
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
Automated agent commit — see BRIEF.md.

Closes #20.

Copies `AppHeader.tsx` + `LanguagePicker.tsx` from `design-system/components/` into `src/components/` and replaces all 3 inline `<header>` blocks (main workshop, showLearn, showMyTeams) with the shared component. Adds a local `hideLanguagePicker` prop (app-specific extension) so facilitator mode still hides the language switcher as before.

Verified with `npm run build` and a headless-browser visual check across all 3 screens.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Bu5ZDqVa6Er689eZXxtuwV)_