### PR TITLE
docs: define goal and roadmap

### DIFF
--- a/.artefacts/GOAL.md
+++ b/.artefacts/GOAL.md
@@ -1,0 +1,19 @@
+# Team Identity — Goal
+
+## Problem
+Agile teams rarely take the time to explicitly define who they are — their name, symbol, shared values, and working agreements — even though Management 3.0's Identity Symbols and Work Expo practices show this shapes how a team collaborates. Team Identity is a guided, single-session workshop tool that walks a facilitator and their team through naming themselves, picking a symbol, selecting shared values, and agreeing on working norms, then produces a shareable team charter — without requiring any account, backend, or setup.
+
+## Audience
+Scrum Masters, Agile coaches, and team facilitators running an in-person or remote Identity Symbols workshop, typically projected onto a shared screen for the whole team to see and vote on live, or run solo by one facilitator per team ahead of a workshop.
+
+## Success criteria
+1. A facilitator can complete the full workshop (intro → name → symbol → values → agreements → charter) in one sitting and end with a finished, readable team charter.
+2. In-progress workshop state survives accidental tab close or refresh (draft auto-save + resume).
+3. A finished charter can leave the browser that created it — via print, image export, or a shareable URL link — with no backend involved.
+4. A facilitator managing multiple teams can save, reload, rename, and compare charters across sessions without losing prior versions.
+5. The app is usable projected in a room (facilitator/projector display mode) and in any of the suite's 4 standard locales (EN/ES/BE/RU).
+
+## Non-goals
+- Not a synced, multi-device backend — all charter data lives in browser `localStorage` only; there is no live collaboration or account system (the `README.md` mention of Firebase is aspirational, not implemented).
+- Not a live multi-user editing tool — one facilitator drives the app through the steps; participants contribute verbally or by consensus, not through simultaneous input.
+- Not a team roster or HR system — participant import from Work Profiles is a one-way, read-only convenience, not a synced membership list.

--- a/.artefacts/ROADMAP.md
+++ b/.artefacts/ROADMAP.md
@@ -1,0 +1,28 @@
+# Team Identity — Roadmap
+
+Derived from GOAL.md. Rebuilt when GOAL changes or an epic ships.
+
+## Current epic
+None — idle. See `## Next epics` below.
+
+## Next epics
+1. **E1: Vitest coverage for charter logic** — serves #2. No test files or test runner exist yet; the app has accumulated non-trivial pure logic (charter history diffing, Scrum-values coverage counting, library 20-item cap/eviction, base64 URL-hash encode/decode) with zero regression protection. [#40](https://github.com/agile-toolkit/team-identity/issues/40) — filed 2026-07-08, `needs-review`, 17 days past the 7-day staleness threshold.
+2. **E2: Charter library JSON export/import** — serves #4. `team-identity:charters` (up to 20 saved teams) and `team-identity:history` live only in the browser that created them; clearing site data or switching devices silently loses everything. [#41](https://github.com/agile-toolkit/team-identity/issues/41) — filed 2026-07-08, `needs-review`, 17 days past the 7-day staleness threshold.
+3. **E3: Decompose App.tsx into per-screen components** — serves ongoing maintainability, not a numbered success criterion directly. `src/App.tsx` has grown to 1017 lines across 10 feature cycles with no screen-level extraction beyond `AppHeader`/`LanguagePicker`/`ThemeToggle`. [#42](https://github.com/agile-toolkit/team-identity/issues/42) — filed 2026-07-11, `needs-review`, 14 days past the 7-day staleness threshold.
+
+## Polish backlog
+- None filed with no issue — all known small items are tracked as GitHub issues above.
+
+## Shipped
+- ~~Core workshop flow (intro → name → symbol → values → agreements → charter) in EN/RU~~
+- ~~Full 4-locale suite parity — ES + BE added, 4-way language switcher~~
+- ~~Charter persistence: draft auto-save/resume, multi-team library (Save/Load/Rename/Delete, capped at 20), version history with side-by-side diff (capped at 10)~~
+- ~~Charter sharing: PNG image export (html2canvas), base64 URL deep-link, print-optimized `@media print` layout~~
+- ~~Cross-app integrations: Moving Motivators top-motivators import, Work Profiles participant import, Dashboard summary key (`team-identity:lastSession`)~~
+- ~~Facilitator/projector display mode for in-room workshops~~
+- ~~Scrum values alignment overlay (badges + coverage row) on the charter~~
+- ~~Keyboard accessibility for symbol/values grids (ARIA roles, roving tabindex)~~
+- ~~Suite design-system adoption: unified `AppHeader`, light/dark theme with anti-flash script~~
+- ~~Main bundle size reduction — code-split `html2canvas` into a lazy chunk (461.76 kB → 259.91 kB)~~
+
+Not carried into Next epics: [#8](https://github.com/agile-toolkit/team-identity/issues/8), [#16](https://github.com/agile-toolkit/team-identity/issues/16), [#18](https://github.com/agile-toolkit/team-identity/issues/18), and [#43](https://github.com/agile-toolkit/team-identity/issues/43) are all "team context banner" integrations scoped entirely to *other* repos (scrum-facilitator, planning-poker, sprint-metrics, change-planner, improvement-board, kanban-designer, work-profiles, salary-formula) — Team Identity's write side (`team-identity-charter`) already exists and needs no further change.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,4 @@
+# Changelog
+
+## Unreleased
+- Docs-only pass: added `.artefacts/GOAL.md` and `.artefacts/ROADMAP.md`, filled in `README.md` with dev commands, localStorage keys, and tech notes, and created this changelog. No behavior change — documents existing functionality that previously only lived in `.artefacts/BRIEF.md`.

--- a/README.md
+++ b/README.md
@@ -1,20 +1,46 @@
 # Team Identity
 
-A team identity workshop tool based on Management 3.0's Identity Symbols and Work Expo practices — collaboratively define your team's name, symbol, values, and working agreements.
+A guided, single-session workshop tool based on Management 3.0's Identity Symbols and Work Expo practices. A facilitator walks a team through naming themselves, picking a symbol, selecting shared values, and agreeing on working norms, then leaves with a shareable team charter — no account, no backend. Available in EN/ES/BE/RU.
 
 Part of the [Agile Tools](https://github.com/bthos) suite built on Management 3.0 and ICAgile source materials.
 
-## Stack
-React 18 · TypeScript · Vite · Tailwind CSS · Firebase · react-i18next (EN/RU)
+See `.artefacts/GOAL.md` for why this app exists and `.artefacts/ROADMAP.md` for what's shipped and what's next.
 
-## Development
+## Stack
+React 18 · TypeScript · Vite · Tailwind CSS · react-i18next (EN/ES/BE/RU)
+
+## Dev commands
 ```bash
-npm install
-npm run dev
+npm install      # install dependencies
+npm run dev       # start Vite dev server
+npm run build      # type-check (tsc) then production build
+npm run preview     # preview the production build locally
 ```
+There is no test script yet — see `.artefacts/ROADMAP.md` E1 (Vitest coverage, issue #40).
 
 ## Deploy
 GitHub Pages via GitHub Actions on push to `main`.
 
+## localStorage keys
+
+| Key | Shape | Purpose |
+|-----|-------|---------|
+| `team-identity-charter` | `TeamCharter` object + `savedAt` timestamp | Full active charter — the source of truth on load |
+| `team-identity:lastSession` | `{teamName, symbol, valuesCount, agreementsCount, membersCount, savedAt}` | Dashboard summary card for agile-toolkit.github.io |
+| `team-identity:draft` | `{charter, step, savedAt}` | In-progress workshop state, written on every step transition; cleared on save or discard |
+| `team-identity:charters` | `Array<SavedCharter>` (max 20, newest first) | Multi-team charter library ("My Teams") |
+| `team-identity:history` | `Array<HistoryEntry>` (max 10, newest first) | Version history per save, used for the diff/compare panel |
+| `team-identity:facilitatorMode` (sessionStorage) | boolean flag | Facilitator/projector display mode, resets per tab session |
+
+Team Identity also *reads* (never writes) two keys owned by sibling apps: `moving-motivators:lastSession` (top-3 ranked motivators, offered as suggested values) and `work-profiles-data` (active participant names, offered as importable team members).
+
+## Tech notes
+- **State management** — a single `App.tsx` component owns all workshop state and step routing (`step` string gates 8 conditional render branches); no external state library. This is a known scaling issue — see `.artefacts/ROADMAP.md` E3 (issue #42) for the planned per-screen component split.
+- **i18n** — `react-i18next` with 4 static JSON locale files (`src/i18n/{en,es,be,ru}.json`), all registered in `src/i18n/index.ts`. No translation is fetched at runtime.
+- **Theme** — dark mode uses Tailwind's `darkMode: ['selector', '[data-theme="dark"]']` convention (shared across the suite). An inline anti-flash script in `index.html` sets `data-theme` on `<html>` before first paint, reading `localStorage.theme` or `prefers-color-scheme`. The branded gradient charter card is intentionally left theme-invariant (self-contained white-on-brand design).
+- **Charter sharing** — image export uses `html2canvas`, dynamically imported inside the "Copy Image" handler (not a static import) so its ~200 kB weight only loads on click. URL sharing base64-encodes the charter JSON into `location.hash`; decoded and hydrated on mount, then the hash is cleared.
+- **Print** — a dedicated `@media print` block in `src/index.css` hides chrome (header, nav, buttons) and strips the charter card's gradient/shadow for a clean printout; `document.title` is set dynamically to `"[TeamName] — Team Charter"` while on the charter step.
+- **Firebase** is referenced as a future collaboration backend but is not wired up anywhere in `src/` — treat any mention as aspirational, not implemented.
+
 ## Source materials
-See `.artefacts/BRIEF.md` for full context and source file references.
+See `.artefacts/BRIEF.md` for the full run-by-run agent history and source file references.


### PR DESCRIPTION
Docs-only pass — no behavior change.

Adds the two agent-maintained documents this repo was missing (parity with `agile-toolkit.github.io`):

- `.artefacts/GOAL.md` — problem statement, audience, success criteria, non-goals
- `.artefacts/ROADMAP.md` — current epic (none), next epics (derived from open GitHub issues #40, #41, #42 — all past the 7-day `needs-review` staleness threshold as of today), polish backlog, shipped log
- `README.md` — added intro line, Dev commands, `## localStorage keys` table, `## Tech notes`, and links to the new GOAL/ROADMAP docs
- `CHANGELOG.md` — created, with an `## Unreleased` entry for this docs-only pass

Source material (`.artefacts/BRIEF.md`) was read but left untouched — it remains the human-authored run-by-run log.


---
_Generated by [Claude Code](https://claude.ai/code/session_01DqHwojggZNH6G3ZhoqjhiW)_